### PR TITLE
Fix example to use 'pReflect' instead of 'reflect'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ const promises = [
 	getPromise()
 ];
 
-Promise.all(promises.map(reflect)).then(result => {
+Promise.all(promises.map(pReflect)).then(result => {
 	console.log(result);
 	/*
 	[{


### PR DESCRIPTION
Since 'reflect' is unassigned and 'pReflect' was declared at the beginning of the code, the example now is using the declared variable.

# TODO

- [x] Update `reflect` to `pReflect` on `readme.md` example.