### PR TITLE
Adapt to the return value of Promise.allSettled

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 export interface PromiseFulfilledResult<ValueType> {
 	status: 'fulfilled';
+	value: ValueType;
 	isFulfilled: true;
 	isRejected: false;
-	value: ValueType;
 }
 
 export interface PromiseRejectedResult {
 	status: 'rejected';
+	reason: unknown;
 	isFulfilled: false;
 	isRejected: true;
-	reason: unknown;
 }
 
 export type PromiseResult<ValueType> =
@@ -41,21 +41,21 @@ console.log(results);
 [
 	{
 		status: 'fulfilled',
-		isFulfilled: true,
-		isRejected: false,
 		value: '🦄'
+		isFulfilled: true,
+		isRejected: false
 	},
 	{
 		status: 'rejected',
-		isFulfilled: false,
-		isRejected: true,
 		reason: [Error: 👹]
+		isFulfilled: false,
+		isRejected: true
 	},
 	{
 		status: 'fulfilled',
-		isFulfilled: true,
-		isRejected: false,
 		value: '🐴'
+		isFulfilled: true,
+		isRejected: false
 	}
 ]
 *\/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,12 @@
 export interface PromiseFulfilledResult<ValueType> {
+	status: 'fulfilled';
 	isFulfilled: true;
 	isRejected: false;
 	value: ValueType;
 }
 
 export interface PromiseRejectedResult {
+	status: 'rejected';
 	isFulfilled: false;
 	isRejected: true;
 	reason: unknown;
@@ -38,16 +40,19 @@ console.log(results);
 /*
 [
 	{
+		status: 'fulfilled',
 		isFulfilled: true,
 		isRejected: false,
 		value: '🦄'
 	},
 	{
+		status: 'rejected',
 		isFulfilled: false,
 		isRejected: true,
 		reason: [Error: 👹]
 	},
 	{
+		status: 'fulfilled',
 		isFulfilled: true,
 		isRejected: false,
 		value: '🐴'

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,15 +74,11 @@ PromiseResult<ValueType>
 >;
 
 /**
-Narrows a variable of type PromiseResult to type PromiseFulfilledResult if the variable has the property 'value', otherwise narrows it to PromiseRejectedResult type.
-@param promiseResult - a variable of type PromiseResult
-@returns boolean
+Narrows a variable of type `PromiseResult` to type `PromiseFulfilledResult` if the variable has the property `value`, otherwise narrows it to the `PromiseRejectedResult` type.
 */
 export function isFulfilled<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseFulfilledResult<T>;
 
 /**
-Narrows a variable of type PromiseResult to type PromiseRejectedResult if the variable has the property 'reason', otherwise narrows it to PromiseFulfilledResult type.
-@param promiseResult - a variable of type PromiseResult
-@returns boolean
+Narrows a variable of type `PromiseResult` to type `PromiseRejectedResult` if the variable has the property `reason`, otherwise narrows it to the `PromiseFulfilledResult` type.
 */
 export function isRejected<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseRejectedResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,16 @@ export default function pReflect<ValueType>(promise: PromiseLike<ValueType>): Pr
 PromiseResult<ValueType>
 >;
 
+/**
+Narrows a variable of type PromiseResult to type PromiseFulfilledResult if the variable has the property 'value', otherwise narrows it to PromiseRejectedResult type.
+@param promiseResult - a variable of type PromiseResult
+@returns boolean
+*/
 export function isFulfilled<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseFulfilledResult<T>;
 
+/**
+Narrows a variable of type PromiseResult to type PromiseRejectedResult if the variable has the property 'reason', otherwise narrows it to PromiseFulfilledResult type.
+@param promiseResult - a variable of type PromiseResult
+@returns boolean
+*/
 export function isRejected<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseRejectedResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,3 +72,7 @@ console.log(resolvedString);
 export default function pReflect<ValueType>(promise: PromiseLike<ValueType>): Promise<
 PromiseResult<ValueType>
 >;
+
+export function isFulfilled<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseFulfilledResult<T>;
+
+export function isRejected<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseRejectedResult;

--- a/index.js
+++ b/index.js
@@ -17,3 +17,11 @@ export default async function pReflect(promise) {
 		};
 	}
 }
+
+export function isFulfilled(promiseResult) {
+	return 'value' in promiseResult;
+}
+
+export function isRejected(promiseResult) {
+	return 'reason' in promiseResult;
+}

--- a/index.js
+++ b/index.js
@@ -4,16 +4,16 @@ export default async function pReflect(promise) {
 
 		return {
 			status: 'fulfilled',
+			value,
 			isFulfilled: true,
-			isRejected: false,
-			value
+			isRejected: false
 		};
 	} catch (error) {
 		return {
 			status: 'rejected',
+			reason: error,
 			isFulfilled: false,
-			isRejected: true,
-			reason: error
+			isRejected: true
 		};
 	}
 }

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ export default async function pReflect(promise) {
 		const value = await promise;
 
 		return {
+			status: 'fulfilled',
 			isFulfilled: true,
 			isRejected: false,
 			value
 		};
 	} catch (error) {
 		return {
+			status: 'rejected',
 			isFulfilled: false,
 			isRejected: true,
 			reason: error

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,10 +4,12 @@ import pReflect from './index.js';
 const result = await pReflect(Promise.resolve('foo'));
 
 if (result.isFulfilled) {
+	expectType<'fulfilled'>(result.status);
 	expectType<true>(result.isFulfilled);
 	expectType<false>(result.isRejected);
 	expectType<string>(result.value);
 } else {
+	expectType<'rejected'>(result.status);
 	expectType<false>(result.isFulfilled);
 	expectType<true>(result.isRejected);
 	expectType<unknown>(result.reason);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,12 +5,12 @@ const result = await pReflect(Promise.resolve('foo'));
 
 if (isFulfilled(result)) {
 	expectType<'fulfilled'>(result.status);
+	expectType<string>(result.value);
 	expectType<true>(result.isFulfilled);
 	expectType<false>(result.isRejected);
-	expectType<string>(result.value);
 } else {
 	expectType<'rejected'>(result.status);
+	expectType<unknown>(result.reason);
 	expectType<false>(result.isFulfilled);
 	expectType<true>(result.isRejected);
-	expectType<unknown>(result.reason);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,9 @@
 import {expectType} from 'tsd';
-import pReflect from './index.js';
+import pReflect, {isFulfilled} from './index.js';
 
 const result = await pReflect(Promise.resolve('foo'));
 
-if (result.isFulfilled) {
+if (isFulfilled(result)) {
 	expectType<'fulfilled'>(result.status);
 	expectType<true>(result.isFulfilled);
 	expectType<false>(result.isRejected);

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ $ npm install p-reflect
 Here, `Promise.all` would normally fail early because one of the promises rejects, but by using `p-reflect`, we can ignore the rejection and handle it later on.
 
 ```js
-import pReflect from 'p-reflect';
+import pReflect, {isFulfilled} from 'p-reflect';
 
 const promises = [
 	getPromise(),
@@ -50,7 +50,7 @@ console.log(results);
 */
 
 const resolvedString = results
-	.filter(result => result.isFulfilled)
+	.filter(isFulfilled)
 	.map(result => result.value)
 	.join('');
 
@@ -78,6 +78,25 @@ The object has the following properties:
 Type: `Promise`
 
 A promise to reflect upon.
+
+### isFulfilled(object)
+
+Returns a `Boolean`.
+
+Returns 'true' if the object has the property 'value'.
+
+This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseFulfilledResult` or `PromiseRejectedResult`
+
+- this is a workaround for [microsoft/TypeScript#32399](https://github.com/microsoft/TypeScript/issues/32399)
+- reference documentation [Using type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html)
+
+### isRejected(object)
+
+Returns a `Boolean`.
+
+Returns 'true' if the object has the property 'reason'.
+
+This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseRejectedResult` or `PromiseFulfilledResult`
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -29,16 +29,19 @@ console.log(results);
 /*
 [
 	{
+		status: 'fulfilled',
 		isFulfilled: true,
 		isRejected: false,
 		value: '🦄'
 	},
 	{
+		status: 'rejected',
 		isFulfilled: false,
 		isRejected: true,
 		reason: [Error: 👹]
 	},
 	{
+		status: 'fulfilled',
 		isFulfilled: true,
 		isRejected: false,
 		value: '🐴'
@@ -65,6 +68,7 @@ Returns a `Promise<Object>`.
 
 The object has the following properties:
 
+- `status` *('fulfilled' or 'rejected', Depending on whether the promise fulfilled or rejected)*
 - `isFulfilled`
 - `isRejected`
 - `value` or `reason` *(Depending on whether the promise fulfilled or rejected)*

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ $ npm install p-reflect
 Here, `Promise.all` would normally fail early because one of the promises rejects, but by using `p-reflect`, we can ignore the rejection and handle it later on.
 
 ```js
-import pReflect, {isFulfilled} from 'p-reflect';
+import pReflect from 'p-reflect';
 
 const promises = [
 	getPromise(),
@@ -50,7 +50,7 @@ console.log(results);
 */
 
 const resolvedString = results
-	.filter(isFulfilled)
+	.filter(result => result.isFulfilled)
 	.map(result => result.value)
 	.join('');
 

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Returns a `Promise<Object>`.
 
 The object has the following properties:
 
-- `status` *('fulfilled' or 'rejected', Depending on whether the promise fulfilled or rejected)*
+- `status` *(`'fulfilled'` or `'rejected'`, depending on how the promise resolved)*
 - `value` or `reason` *(Depending on whether the promise fulfilled or rejected)*
 - `isFulfilled`
 - `isRejected`

--- a/readme.md
+++ b/readme.md
@@ -81,22 +81,22 @@ A promise to reflect upon.
 
 ### isFulfilled(object)
 
-Returns a `Boolean`.
+This is a type guard for TypeScript users.
 
-Returns 'true' if the object has the property 'value'.
+Returns `true` if the object has the property `value`, `false` otherwise.
 
-This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseFulfilledResult` or `PromiseRejectedResult`
+This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseFulfilledResult` or `PromiseRejectedResult`.
 
-- this is a workaround for [microsoft/TypeScript#32399](https://github.com/microsoft/TypeScript/issues/32399)
+This is a workaround for [microsoft/TypeScript#32399](https://github.com/microsoft/TypeScript/issues/32399)
 - reference documentation [Using type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html)
 
 ### isRejected(object)
 
-Returns a `Boolean`.
+This is a type guard for TypeScript users.
 
-Returns 'true' if the object has the property 'reason'.
+Returns `true` if the object has the property `reason`, `false` otherwise.
 
-This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseRejectedResult` or `PromiseFulfilledResult`
+This is useful since `await pReflect(promise)` always returns a `PromiseResult`. This function can be used to determine whether `PromiseResult` is `PromiseRejectedResult` or `PromiseFulfilledResult`.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -30,21 +30,21 @@ console.log(results);
 [
 	{
 		status: 'fulfilled',
-		isFulfilled: true,
-		isRejected: false,
 		value: '🦄'
+		isFulfilled: true,
+		isRejected: false
 	},
 	{
 		status: 'rejected',
-		isFulfilled: false,
-		isRejected: true,
 		reason: [Error: 👹]
+		isFulfilled: false,
+		isRejected: true
 	},
 	{
 		status: 'fulfilled',
-		isFulfilled: true,
-		isRejected: false,
 		value: '🐴'
+		isFulfilled: true,
+		isRejected: false
 	}
 ]
 */
@@ -69,9 +69,9 @@ Returns a `Promise<Object>`.
 The object has the following properties:
 
 - `status` *('fulfilled' or 'rejected', Depending on whether the promise fulfilled or rejected)*
+- `value` or `reason` *(Depending on whether the promise fulfilled or rejected)*
 - `isFulfilled`
 - `isRejected`
-- `value` or `reason` *(Depending on whether the promise fulfilled or rejected)*
 
 #### promise
 

--- a/test.js
+++ b/test.js
@@ -8,9 +8,9 @@ test('main', async t => {
 		await pReflect(Promise.resolve(fixture)),
 		{
 			status: 'fulfilled',
+			value: fixture,
 			isFulfilled: true,
-			isRejected: false,
-			value: fixture
+			isRejected: false
 		}
 	);
 
@@ -18,9 +18,9 @@ test('main', async t => {
 		await pReflect(Promise.reject(fixture)),
 		{
 			status: 'rejected',
+			reason: fixture,
 			isFulfilled: false,
-			isRejected: true,
-			reason: fixture
+			isRejected: true
 		}
 	);
 });

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ test('main', async t => {
 	t.deepEqual(
 		await pReflect(Promise.resolve(fixture)),
 		{
+			status: 'fulfilled',
 			isFulfilled: true,
 			isRejected: false,
 			value: fixture
@@ -16,6 +17,7 @@ test('main', async t => {
 	t.deepEqual(
 		await pReflect(Promise.reject(fixture)),
 		{
+			status: 'rejected',
 			isFulfilled: false,
 			isRejected: true,
 			reason: fixture


### PR DESCRIPTION
When I use p-settle to replace Promise.allSettled in my project for throttling, I want its return value can be adapted to the return of Promise.allSettled

Fixes #8