### PR TITLE
Add support for Error Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,16 +5,16 @@ export interface PromiseFulfilledResult<ValueType> {
 	isRejected: false;
 }
 
-export interface PromiseRejectedResult {
+export interface PromiseRejectedResult<ErrorType = unknown> {
 	status: 'rejected';
-	reason: unknown;
+	reason: ErrorType;
 	isFulfilled: false;
 	isRejected: true;
 }
 
-export type PromiseResult<ValueType> =
+export type PromiseResult<ValueType, ErrorType = unknown> =
 	| PromiseFulfilledResult<ValueType>
-	| PromiseRejectedResult;
+	| PromiseRejectedResult<ErrorType>;
 
 /**
 Make a promise always fulfill with its actual fulfillment value or rejection reason.
@@ -69,16 +69,20 @@ console.log(resolvedString);
 //=> '🦄🐴'
 ```
 */
-export default function pReflect<ValueType>(promise: PromiseLike<ValueType>): Promise<
-PromiseResult<ValueType>
->;
+export default function pReflect<ValueType, ErrorType = unknown>(
+	promise: PromiseLike<ValueType>
+): Promise<PromiseResult<ValueType, ErrorType>>;
 
 /**
 Narrows a variable of type `PromiseResult` to type `PromiseFulfilledResult` if the variable has the property `value`, otherwise narrows it to the `PromiseRejectedResult` type.
 */
-export function isFulfilled<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseFulfilledResult<T>;
+export function isFulfilled<T>(
+	promiseResult: PromiseResult<T>
+): promiseResult is PromiseFulfilledResult<T>;
 
 /**
 Narrows a variable of type `PromiseResult` to type `PromiseRejectedResult` if the variable has the property `reason`, otherwise narrows it to the `PromiseFulfilledResult` type.
 */
-export function isRejected<T>(promiseResult: PromiseResult<T>): promiseResult is PromiseRejectedResult;
+export function isRejected<T, E = unknown>(
+	promiseResult: PromiseResult<T>
+): promiseResult is PromiseRejectedResult<E>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import pReflect, {isFulfilled} from './index.js';
+import pReflect, {isFulfilled, isRejected} from './index.js';
 
 const result = await pReflect(Promise.resolve('foo'));
 
@@ -13,4 +13,15 @@ if (isFulfilled(result)) {
 	expectType<unknown>(result.reason);
 	expectType<false>(result.isFulfilled);
 	expectType<true>(result.isRejected);
+}
+
+const resultWithErrorType = await pReflect<string, Error>(
+	Promise.reject(new Error('foo'))
+);
+
+if (isRejected(resultWithErrorType)) {
+	expectType<'rejected'>(resultWithErrorType.status);
+	expectType<Error>(resultWithErrorType.reason);
+	expectType<false>(resultWithErrorType.isFulfilled);
+	expectType<true>(resultWithErrorType.isRejected);
 }


### PR DESCRIPTION
I like this module a lot! I think it would be even better if we were able to define possible resulting errors. I've adding backwards-compatible types for errors here, people might use this when they have known errors being returned by a function.

At seam.co we have really error-heavy code, so we usually have types for all the errors that could be returned by a function. This might be one step towards getting all those errors nicely typed.

Example code BEFORE ErrorType introduced:

```ts
  const result = await pReflect(
    getFromGithub("/users/thispersondoesnotexist99829384", {})
  )
  if (isRejected(result)) {
    result.reason // type: unknown
  }
```

Example code after:

```ts
const result = await pReflect<APIResponse, NotFoundError>(
  getFromGithub("/users/thispersondoesnotexist99829384", {})
)

if (isRejected(result)) {
  result.reason // type: NotFoundError
}
```

I'm interested in comments but I think due to [Typescript's all-or-nothing generics](https://github.com/microsoft/TypeScript/issues/10571) this feature might not be very helpful. (see how I have to include APIResponse in the AFTER type above?)